### PR TITLE
Use printf instead of echo.

### DIFF
--- a/tpm
+++ b/tpm
@@ -91,7 +91,8 @@ insert() {
   fi
 
   mkdir -p "$(dirname "${entry_path}")"
-  echo "${password}" | gpg2 ${GPG_OPTS} --encrypt --output "${entry_path}"
+  printf '%s\n' "${password}" | gpg2 \
+    ${GPG_OPTS} --encrypt --output "${entry_path}"
 }
 
 ##


### PR DESCRIPTION
`echo` is [quirky](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html). Backslashes may (or may not) be expanded and using `-n` as a password (I hope you don't, but still) could (or could not) work. `printf` solves all those problems!

Was the ending newline needed?
