### PR TITLE
Use printf instead of echo.

### DIFF
--- a/tpm
+++ b/tpm
@@ -32,7 +32,7 @@ fi
 ##
 
 abort() {
-  echo "${1}" 1>&2
+  printf '%s\n' "${1}" 1>&2
   exit 1
 }
 


### PR DESCRIPTION
This changes `echo` to `printf` for a few reasons.

1. `echo` is only fully portable for plain text wrapped in single quotes and `"${1}"` may or may not be that, using `printf` instead makes the `abort` function more robust.
2. The posix spec strongly suggests using `printf` instead of `echo`.
3. This is the last use of `echo` and `printf` is already used in several places so this essentially accomplishes the same with less tools.