### PR TITLE
Silence shellcheck warning.

### DIFF
--- a/tpm
+++ b/tpm
@@ -88,7 +88,7 @@ insert() {
   password=""
   readpw "Password for '${entry_name}': " password
   if [ -t 0 ]; then
-    printf "\n"
+    printf '\n'
   fi
 
   if [ -z "${password}" ]; then


### PR DESCRIPTION
Silences the follow warning for http://www.shellcheck.net/
```
Line 91:
    printf "\n"
            ^-- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".
```
See this for more information.
https://github.com/koalaman/shellcheck/wiki/SC1117

Better uses would be `printf "\\n"` or `printf '\n'` where I opted for the latter here.