### PR TITLE
Makefile: Silence mandoc warning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ MANDIR ?= $(PREFIX)/share/man
 
 all: tpm.1
 tpm.1: README.pod
-	pod2man --section=1 --center="tpm Manual" --name="tpm" \
+	pod2man --section=1 --center="tpm Manual" --name="TPM" \
 		--release="tpm $(VERSION)" $< $@
 
 install: tpm.1


### PR DESCRIPTION
This silences the following warning found by mandoc's lint feature. This can be easily fixed by adjusting the Makefile which generates `tpm.1`.
```
man -Tlint tpm
```
```
tpm.1:132:5: STYLE: lower case character in document title: TH tpm
```
```
lower case character in document title
  (mdoc, man) The title is still used as given in the Dt or TH macro.
```
https://man.openbsd.org/mandoc.1