### PR TITLE
Fix tpm with zsh

### DIFF
--- a/tpm
+++ b/tpm
@@ -20,7 +20,6 @@ umask 077
 # Variables
 ##
 
-GPG_OPTS="--quiet --yes --batch"
 STORE_DIR="${PASSWORD_STORE_DIR:-${HOME}/.password-store}"
 
 if [ -r "${STORE_DIR}/.gpg-id" ] && [ -z "${PASSWORD_STORE_KEY}" ]; then
@@ -38,9 +37,9 @@ abort() {
 
 gpg() {
   if [ -n "${PASSWORD_STORE_KEY}" ]; then
-    gpg2 $GPG_OPTS --recipient "${PASSWORD_STORE_KEY}" "$@"
+    gpg2 --quiet --yes --batch --recipient "${PASSWORD_STORE_KEY}" "$@"
   else
-    gpg2 $GPG_OPTS --default-recipient-self "$@"
+    gpg2 --quiet --yes --batch --default-recipient-self "$@"
   fi
 }
 


### PR DESCRIPTION
I don't really use `zsh`, but tried it with `tpm` out of curiosity and not surprisingly it failed because `zsh` doesn't split variables when they are unquoted. I used a POSIX method using `eval` to work with arrays which will explicitly split the `gpg2` arguments and now `tpm` also works with `zsh`. These arrays are portable to the following shells, `ash`, `bash`, `dash`, `ksh`, `mksh`, `pdksh`, `posh`, `yash` and `zsh`. Note I have not tried most of these shells yet, I just anticipated that `zsh` would be the more problematic.

I'm not sure you want this patch, but I thought I would share it in case. Also, I think this use of `eval` is safe since users will have to escape any problematic characters (`` $ \ " '`) to pass them to `tpm` in the first place, but a second opinion is of course appreciated. I know some ways to make it safer if needed.

This also silences the last two shellcheck.net warnings.
```
Line 41:
    gpg2 $GPG_OPTS --recipient "${PASSWORD_STORE_KEY}" "$@"
         ^-- SC2086: Double quote to prevent globbing and word splitting.

Line 43:
    gpg2 $GPG_OPTS --default-recipient-self "$@"
         ^-- SC2086: Double quote to prevent globbing and word splitting.
```
https://github.com/koalaman/shellcheck/wiki/SC2086