### PR TITLE
Optionally allow existing entries to be overridden

### DIFF
--- a/tpm
+++ b/tpm
@@ -81,7 +81,7 @@ insert() {
     abort "USAGE: tpm insert ENTRY"
   fi
 
-  if [ -e "${entry_path}" ]; then
+  if [ -z "${TPM_FORCE}" ] && [ -e "${entry_path}" ]; then
     abort "This entry already exists, please remove it first."
   fi
 


### PR DESCRIPTION
If TPM_FORCE is set, then skip the check to see if the target already
exists. This allows data to be overridden without manually having to
remove existing entries.